### PR TITLE
 HF changes to cjp v28 for EDGAR

### DIFF
--- a/dqc_us_rules/source/lib/functions.xule
+++ b/dqc_us_rules/source/lib/functions.xule
@@ -1030,7 +1030,7 @@ function concept_pair_from_name_pair($pair)
 
 function applicable_form($ruleName)
 		$rule_number = ($ruleName.split('.'))[($ruleName.split('.').length)-1];
-		$ApplicableForms = $RULE-FORM-LOOKUP[$rule_number]
+		$ApplicableForms = $RULE-FORM-LOOKUPc[$rule_number]
 		$ApplicableForms.contains($DOCUMENT_TYPE) or  $DOCUMENT_TYPE == none or $ApplicableForms == none
 
 /**
@@ -1045,5 +1045,5 @@ function applicable_form($ruleName)
 
 
 function applicable_form_string($ruleNnumber)
-		$ApplicableForms = $RULE-FORM-LOOKUP[$ruleNnumber]
+		$ApplicableForms = $RULE-FORM-LOOKUPc[$ruleNnumber]
 		$ApplicableForms.contains($DOCUMENT_TYPE) or  $DOCUMENT_TYPE == none or $ApplicableForms == none

--- a/dqc_us_rules/source/us/2023/DQC_0156.xule
+++ b/dqc_us_rules/source/us/2023/DQC_0156.xule
@@ -27,8 +27,6 @@ $invalidItem = {@concept in $BasicAndDilutedIExtensionItems where $fact.concept.
 
 exists($invalidItem)
 
-exists($invalidItem)
-
 message
 "The filer has reported a value of {$invalidItem}  using the extension concept {$invalidItem.concept.name}. This value should be tagged with separate  US GAAP elements for the Basic amount and the diluted amount.  This means the same fact needs to be tagged with separate elements.  An extension element should not be used to tag this fact.
 

--- a/dqc_us_rules/source/us/2023/DQC_0182.xule
+++ b/dqc_us_rules/source/us/2023/DQC_0182.xule
@@ -28,10 +28,10 @@ $lookupDict = $dimEquivs.agg-to-dict(1)
 for $key in $lookupDict.keys
      $base = {@concept = $key};
      if exists($base)
-          $keyValues = filter $lookupDict[$key] returns $item;
-          $axis = (filter $keyValues where $item[2].substitution == xbrldt:dimensionItem returns $item[2].name).first;
-          $member = (filter $keyValues where $item[2].data-type.name == dtr-types:domainItemType returns $item[2]).first;
-          $lineItem = (filter $keyValues where $item[2].data-type.name != dtr-types:domainItemType and  $item[2].substitution != xbrldt:dimensionItem returns $item[2]).first;
+          $keyValues = filter $lookupDict[$key] returns taxonomy().concept($item[2]);
+          $axis = (filter $keyValues where $item.substitution == xbrldt:dimensionItem returns $item.name).first;
+          $member = (filter $keyValues where $item.data-type.name == dtr-types:domainItemType returns $item).first;
+          $lineItem = (filter $keyValues where $item.data-type.name != dtr-types:domainItemType and  $item.substitution != xbrldt:dimensionItem returns $item).first;
           
           $multiplier = (if $lineItem.balance != $key.balance
                               0 -1 

--- a/dqc_us_rules/source/us/2023/constant-us-gaap.xule
+++ b/dqc_us_rules/source/us/2023/constant-us-gaap.xule
@@ -332,7 +332,7 @@ constant $ASU201613_TRANSITION_ELEMENTS = navigate parent-child descendants from
 
 /* DQC_0182 */
 
-constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2023/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source, target)
+constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2023/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source-name, target-name)
 
 /* DQC_0183 not available for 2023, dummy variable for build shell script */
 
@@ -372,3 +372,6 @@ constant $INTANGIBLE_INDEFINITE_ASSETS_MEMBERS = navigate domain-member descenda
 constant $INTANGIBLE_MONETARY_ITEMS = navigate parent-child descendants from list(IntangibleAssetsDisclosureTextBlock) taxonomy $US-GAAP where $relationship.target.is-monetary == true returns set (target-name)
 
 constant $INTANGIBLE_DURATION_ITEMS = navigate parent-child descendants from list(IntangibleAssetsDisclosureTextBlock) taxonomy $US-GAAP where $relationship.target.data-type.name == xbrli:durationItemType  returns set (target-name)
+
+constant $RULE-FORM-LOOKUPc = $RULE-FORM-LOOKUP
+

--- a/dqc_us_rules/source/us/2023/constant.xule
+++ b/dqc_us_rules/source/us/2023/constant.xule
@@ -100,7 +100,7 @@ constant $NON_ADDITIVE_DURATION_CONCEPTS = set()
 
 constant $OCI_TOTALS = list(OtherComprehensiveIncomeLossNetOfTax, OtherComprehensiveIncomeLossBeforeTax, OtherComprehensiveIncomeLossNetOfTaxPortionAttributableToParent, OtherComprehensiveIncomeLossBeforeTaxPortionAttributableToParent)
 
-constant $INCOME_LOSS_EXTENSION_ITEMS = filter$EXTENSION_CONCEPTS where $item.balance == credit and $item.name.local-name.lower-case.contains('incomeloss') and not $item.name.local-name.lower-case.contains('equitymethod') and not $item.name.local-name.lower-case.contains('equityincomeloss') returns $item.name
+constant $INCOME_LOSS_EXTENSION_ITEMS = filter $EXTENSION_CONCEPTS where $item.balance == credit and $item.name.local-name.lower-case.contains('incomeloss') and not $item.name.local-name.lower-case.contains('equitymethod') and not $item.name.local-name.lower-case.contains('equityincomeloss') returns $item.name
 
 constant $INCOME_ITEMS = set(
 					ComprehensiveIncomeNetOfTax,

--- a/dqc_us_rules/source/us/2024/DQC_0182.xule
+++ b/dqc_us_rules/source/us/2024/DQC_0182.xule
@@ -29,10 +29,10 @@ $lookupDict = $dimEquivs.agg-to-dict(1)
 for $key in $lookupDict.keys
      $base = {@concept = $key};
      if exists($base)
-          $keyValues = filter $lookupDict[$key] returns $item;
-          $axis = (filter $keyValues where $item[2].substitution == xbrldt:dimensionItem returns $item[2].name).first;
-          $member = (filter $keyValues where $item[2].data-type.name == dtr-types:domainItemType returns $item[2]).first;
-          $lineItem = (filter $keyValues where $item[2].data-type.name != dtr-types:domainItemType and  $item[2].substitution != xbrldt:dimensionItem returns $item[2]).first;
+          $keyValues = filter $lookupDict[$key] returns taxonomy().concept($item[2]);
+          $axis = (filter $keyValues where $item.substitution == xbrldt:dimensionItem returns $item.name).first;
+          $member = (filter $keyValues where $item.data-type.name == dtr-types:domainItemType returns $item).first;
+          $lineItem = (filter $keyValues where $item.data-type.name != dtr-types:domainItemType and  $item.substitution != xbrldt:dimensionItem returns $item).first;
           
           $multiplier = (if $lineItem.balance != $key.balance
                               0 -1 

--- a/dqc_us_rules/source/us/2024/constant-us-gaap.xule
+++ b/dqc_us_rules/source/us/2024/constant-us-gaap.xule
@@ -332,7 +332,7 @@ constant $ASU201613_TRANSITION_ELEMENTS = navigate parent-child descendants from
 
 /* DQC_0182 */
 
-constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2021/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source, target)
+constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2021/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source-name, target-name)
 
 /* DQC_0183 */
 
@@ -376,4 +376,5 @@ constant $INTANGIBLE_MONETARY_ITEMS = navigate parent-child descendants from lis
 
 constant $INTANGIBLE_DURATION_ITEMS = navigate parent-child descendants from list(IntangibleAssetsDisclosureTextBlock) taxonomy $US-GAAP where $relationship.target.data-type.name == xbrli:durationItemType  returns set (target-name)
 
+constant $RULE-FORM-LOOKUPc = $RULE-FORM-LOOKUP
 	 

--- a/dqc_us_rules/source/us/2025/DQC_0182.xule
+++ b/dqc_us_rules/source/us/2025/DQC_0182.xule
@@ -28,10 +28,10 @@ $lookupDict = $dimEquivs.agg-to-dict(1)
 for $key in $lookupDict.keys
      $base = {@concept = $key};
      if exists($base)
-          $keyValues = filter $lookupDict[$key] returns $item;
-          $axis = (filter $keyValues where $item[2].substitution == xbrldt:dimensionItem returns $item[2].name).first;
-          $member = (filter $keyValues where $item[2].data-type.name == dtr-types:domainItemType returns $item[2]).first;
-          $lineItem = (filter $keyValues where $item[2].data-type.name != dtr-types:domainItemType and  $item[2].substitution != xbrldt:dimensionItem returns $item[2]).first;
+          $keyValues = filter $lookupDict[$key] returns taxonomy().concept($item[2]);
+          $axis = (filter $keyValues where $item.substitution == xbrldt:dimensionItem returns $item.name).first;
+          $member = (filter $keyValues where $item.data-type.name == dtr-types:domainItemType returns $item).first;
+          $lineItem = (filter $keyValues where $item.data-type.name != dtr-types:domainItemType and  $item.substitution != xbrldt:dimensionItem returns $item).first;
           
           $multiplier = (if $lineItem.balance != $key.balance
                               0 -1 

--- a/dqc_us_rules/source/us/2025/constant-us-gaap.xule
+++ b/dqc_us_rules/source/us/2025/constant-us-gaap.xule
@@ -331,7 +331,7 @@ constant $ASU201613_TRANSITION_ELEMENTS = navigate parent-child descendants from
 
 /* DQC_0182 */
 
-constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2021/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source, target)
+constant $DIM_EQUIV_NAMES = navigate 'http://www.xbrl.org/2021/arcrole/concept-dimensional-equivalent' descendants  taxonomy $META returns list (source-name, target-name)
 
 /* DQC_0183 */
 
@@ -374,3 +374,6 @@ constant $INTANGIBLE_INDEFINITE_ASSETS_MEMBERS = navigate domain-member descenda
 constant $INTANGIBLE_MONETARY_ITEMS = navigate parent-child descendants from list(IntangibleAssetsDisclosureTextBlock) taxonomy $US-GAAP where $relationship.target.is-monetary == true returns set (target-name)
 
 constant $INTANGIBLE_DURATION_ITEMS = navigate parent-child descendants from list(IntangibleAssetsDisclosureTextBlock) taxonomy $US-GAAP where $relationship.target.data-type.name == xbrli:durationItemType  returns set (target-name)
+
+constant $RULE-FORM-LOOKUPc = $RULE-FORM-LOOKUP
+


### PR DESCRIPTION
add constant for applicable forms, correct 2023 syntax error, change0182 to qnames

### Changes:

- applicable_form: create precompiled constant $RULE-FORM-LOOKUPc from $RULE-FORM-LOOKUP because csv table is not accessible to prod at run time
- 2023 constants.xule: blank missing after keyword filter
- DQC_0182: change constant $DIM_EQUIV_NAMES to qnames because concept objects aren't precompilable or reloadable, change corresponding logic to use qnames in rule
- DQC_0156: typo - two exists.

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.